### PR TITLE
Initialize Novo Unity Configurator Lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# unityConfiguratorAi
+# Novo Unity Configurator Lite
+
+This project provides a starter React + TypeScript configurator created with Vite.
+It offers a simple stepper to collect the following information:
+
+1. Choose setup: **Unity Arena** or **8 pod island**
+2. Configure locations with name and number of setups
+3. Select available games
+4. Decide whether a jackpot is required
+5. Decide whether wide area network functionality is required
+
+Each configuration is represented as JSON and shown after completing the stepper.
+
+Run scripts:
+
+```
+npm run dev     # start development server
+npm run build   # build for production
+npm test        # run placeholder tests
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Novo Unity Configurator Lite</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "unityconfiguratorai",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+import Configurator from './components/Configurator';
+
+export default function App() {
+  const [started, setStarted] = useState(false);
+
+  return (
+    <div>
+      {!started ? (
+        <div>
+          <h1>Novo Unity Pro configurator</h1>
+          <button onClick={() => setStarted(true)}>
+            Let's configure a unity together
+          </button>
+        </div>
+      ) : (
+        <Configurator />
+      )}
+    </div>
+  );
+}

--- a/src/components/Configurator.tsx
+++ b/src/components/Configurator.tsx
@@ -1,0 +1,173 @@
+import { useState } from 'react';
+
+export interface SetupConfig {
+  setupType: 'Unity Arena' | '8 pod island';
+  locations: { name: string; count: number }[];
+  games: Record<string, { enabled: boolean }>;
+  jackpot: boolean;
+  wideArea: boolean;
+}
+
+const gameNames = [
+  'roulette',
+  'baccarat',
+  'blackjack',
+  'sic-bo',
+  'poker',
+  'slot games'
+];
+
+export default function Configurator() {
+  const [step, setStep] = useState(0);
+  const [config, setConfig] = useState<SetupConfig>({
+    setupType: 'Unity Arena',
+    locations: [{ name: '', count: 1 }],
+    games: Object.fromEntries(gameNames.map((n) => [n, { enabled: false }])),
+    jackpot: false,
+    wideArea: false
+  });
+
+  function updateLocation(index: number, field: 'name' | 'count', value: any) {
+    setConfig((c) => {
+      const locations = [...c.locations];
+      const loc = { ...locations[index], [field]: value };
+      locations[index] = loc;
+      return { ...c, locations };
+    });
+  }
+
+  function addLocation() {
+    setConfig((c) => ({
+      ...c,
+      locations: [...c.locations, { name: '', count: 1 }]
+    }));
+  }
+
+  const next = () => setStep((s) => s + 1);
+  const back = () => setStep((s) => Math.max(s - 1, 0));
+
+  return (
+    <div>
+      {step === 0 && (
+        <div>
+          <h2>Select Setup</h2>
+          <button
+            onClick={() => setConfig((c) => ({ ...c, setupType: 'Unity Arena' }))}
+          >
+            Unity Arena
+          </button>
+          <button
+            onClick={() => setConfig((c) => ({ ...c, setupType: '8 pod island' }))}
+          >
+            8 pod island
+          </button>
+          <div>
+            <button onClick={next}>Next</button>
+          </div>
+        </div>
+      )}
+      {step === 1 && (
+        <div>
+          <h2>Location setup</h2>
+          {config.locations.map((loc, i) => (
+            <div key={i}>
+              <input
+                value={loc.name}
+                placeholder={`Location ${i + 1} name`}
+                onChange={(e) => updateLocation(i, 'name', e.target.value)}
+              />
+              <button
+                onClick={() =>
+                  updateLocation(i, 'count', Math.max(1, loc.count - 1))
+                }
+              >
+                -
+              </button>
+              <span>{loc.count}</span>
+              <button onClick={() => updateLocation(i, 'count', loc.count + 1)}>
+                +
+              </button>
+            </div>
+          ))}
+          <button onClick={addLocation}>Add Location</button>
+          <div>
+            <button onClick={back}>Back</button>
+            <button onClick={next}>Next</button>
+          </div>
+        </div>
+      )}
+      {step === 2 && (
+        <div>
+          <h2>Games</h2>
+          {gameNames.map((name) => (
+            <label key={name} style={{ display: 'block' }}>
+              <input
+                type="checkbox"
+                checked={config.games[name].enabled}
+                onChange={(e) =>
+                  setConfig((c) => ({
+                    ...c,
+                    games: {
+                      ...c.games,
+                      [name]: { enabled: e.target.checked }
+                    }
+                  }))
+                }
+              />
+              {name}
+            </label>
+          ))}
+          <div>
+            <button onClick={back}>Back</button>
+            <button onClick={next}>Next</button>
+          </div>
+        </div>
+      )}
+      {step === 3 && (
+        <div>
+          <h2>Do you need a jackpot?</h2>
+          <label>
+            <input
+              type="checkbox"
+              checked={config.jackpot}
+              onChange={(e) =>
+                setConfig((c) => ({ ...c, jackpot: e.target.checked }))
+              }
+            />
+            Jackpot
+          </label>
+          <div>
+            <button onClick={back}>Back</button>
+            <button onClick={next}>Next</button>
+          </div>
+        </div>
+      )}
+      {step === 4 && (
+        <div>
+          <h2>Do you need a wide area network functionality?</h2>
+          <label>
+            <input
+              type="checkbox"
+              checked={config.wideArea}
+              onChange={(e) =>
+                setConfig((c) => ({ ...c, wideArea: e.target.checked }))
+              }
+            />
+            Wide Area Network
+          </label>
+          <div>
+            <button onClick={back}>Back</button>
+            <button onClick={next}>Finish</button>
+          </div>
+        </div>
+      )}
+      {step === 5 && (
+        <div>
+          <h2>Configuration Summary</h2>
+          <pre>{JSON.stringify(config, null, 2)}</pre>
+          <button onClick={() => setStep(0)}>Start over</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,8 @@
+body {
+  font-family: sans-serif;
+  padding: 2rem;
+}
+
+button {
+  margin: 0.25rem;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- scaffold React + TypeScript app via Vite
- add landing page to start Unity configuration
- implement stepper to capture setup type, locations, games, jackpot and WAN options

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6890c045e6a4832584a01222fb2788dd