### PR TITLE
Initialize Novo Unity Configurator Lite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.log
+npm-debug.log*
+.DS_Store
+.tmp/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# unityConfiguratorAi
+# Novo Unity Configurator Lite
+
+This project provides a starter React + TypeScript configurator created with Vite.
+It offers a simple stepper to collect the following information:
+
+1. Choose setup: **Unity Arena** or **8 pod island**
+2. Configure locations with name and number of setups
+3. Select available games
+4. Decide whether a jackpot is required
+5. Decide whether wide area network functionality is required
+
+After completing the stepper, a dashboard lists the selected games. Each game appears as a card where the environment (e.g. **Flying**, **Multi**, **Touchbet**) can be configured before viewing the final JSON summary.
+
+Run scripts:
+
+```
+npm run dev     # start development server
+npm run build   # build for production
+npm test        # run placeholder tests
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Novo Unity Configurator Lite</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "unityconfiguratorai",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+import Configurator from './components/Configurator';
+
+export default function App() {
+  const [started, setStarted] = useState(false);
+
+  return (
+    <div>
+      {!started ? (
+        <div>
+          <h1>Novo Unity Configurator Lite</h1>
+          <button onClick={() => setStarted(true)}>
+            Let's configure a unity together
+          </button>
+        </div>
+      ) : (
+        <Configurator />
+      )}
+    </div>
+  );
+}

--- a/src/components/Configurator.tsx
+++ b/src/components/Configurator.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react';
+import { gameDefinitions } from '../data/games';
+import Dashboard from './Dashboard';
+
+export interface SetupConfig {
+  setupType: 'Unity Arena' | '8 pod island';
+  locations: { name: string; count: number }[];
+  games: Record<string, { enabled: boolean; environment?: string }>;
+  jackpot: boolean;
+  wideArea: boolean;
+}
+
+const initialGames = Object.fromEntries(
+  gameDefinitions.map((g) => [g.key, { enabled: false }])
+);
+
+export default function Configurator() {
+  const [step, setStep] = useState(0);
+  const [config, setConfig] = useState<SetupConfig>({
+    setupType: 'Unity Arena',
+    locations: [{ name: '', count: 1 }],
+    games: initialGames,
+    jackpot: false,
+    wideArea: false
+  });
+
+  function updateLocation(index: number, field: 'name' | 'count', value: any) {
+    setConfig((c) => {
+      const locations = [...c.locations];
+      const loc = { ...locations[index], [field]: value };
+      locations[index] = loc;
+      return { ...c, locations };
+    });
+  }
+
+  function addLocation() {
+    setConfig((c) => ({
+      ...c,
+      locations: [...c.locations, { name: '', count: 1 }]
+    }));
+  }
+
+  const next = () => setStep((s) => s + 1);
+  const back = () => setStep((s) => Math.max(s - 1, 0));
+
+  return (
+    <div>
+      {step === 0 && (
+        <div>
+          <h2>Select Setup</h2>
+          <button
+            onClick={() => setConfig((c) => ({ ...c, setupType: 'Unity Arena' }))}
+          >
+            Unity Arena
+          </button>
+          <button
+            onClick={() => setConfig((c) => ({ ...c, setupType: '8 pod island' }))}
+          >
+            8 pod island
+          </button>
+          <div>
+            <button onClick={next}>Next</button>
+          </div>
+        </div>
+      )}
+      {step === 1 && (
+        <div>
+          <h2>Location setup</h2>
+          {config.locations.map((loc, i) => (
+            <div key={i}>
+              <input
+                value={loc.name}
+                placeholder={`Location ${i + 1} name`}
+                onChange={(e) => updateLocation(i, 'name', e.target.value)}
+              />
+              <button
+                onClick={() =>
+                  updateLocation(i, 'count', Math.max(1, loc.count - 1))
+                }
+              >
+                -
+              </button>
+              <span>{loc.count}</span>
+              <button onClick={() => updateLocation(i, 'count', loc.count + 1)}>
+                +
+              </button>
+            </div>
+          ))}
+          <button onClick={addLocation}>Add Location</button>
+          <div>
+            <button onClick={back}>Back</button>
+            <button onClick={next}>Next</button>
+          </div>
+        </div>
+      )}
+      {step === 2 && (
+        <div>
+          <h2>Games</h2>
+          {gameDefinitions.map((g) => (
+            <label key={g.key} style={{ display: 'block' }}>
+              <input
+                type="checkbox"
+                checked={config.games[g.key].enabled}
+                onChange={(e) =>
+                  setConfig((c) => ({
+                    ...c,
+                    games: {
+                      ...c.games,
+                      [g.key]: { ...c.games[g.key], enabled: e.target.checked }
+                    }
+                  }))
+                }
+              />
+              {g.name}
+            </label>
+          ))}
+          <div>
+            <button onClick={back}>Back</button>
+            <button onClick={next}>Next</button>
+          </div>
+        </div>
+      )}
+      {step === 3 && (
+        <div>
+          <h2>Do you need a jackpot?</h2>
+          <label>
+            <input
+              type="checkbox"
+              checked={config.jackpot}
+              onChange={(e) =>
+                setConfig((c) => ({ ...c, jackpot: e.target.checked }))
+              }
+            />
+            Jackpot
+          </label>
+          <div>
+            <button onClick={back}>Back</button>
+            <button onClick={next}>Next</button>
+          </div>
+        </div>
+      )}
+      {step === 4 && (
+        <div>
+          <h2>Do you need a wide area network functionality?</h2>
+          <label>
+            <input
+              type="checkbox"
+              checked={config.wideArea}
+              onChange={(e) =>
+                setConfig((c) => ({ ...c, wideArea: e.target.checked }))
+              }
+            />
+            Wide Area Network
+          </label>
+          <div>
+            <button onClick={back}>Back</button>
+            <button onClick={next}>Finish</button>
+          </div>
+        </div>
+      )}
+      {step === 5 && (
+        <Dashboard config={config} setConfig={setConfig} restart={() => setStep(0)} />
+      )}
+    </div>
+  );
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { gameDefinitions } from '../data/games';
+import type { SetupConfig } from './Configurator';
+
+interface DashboardProps {
+  config: SetupConfig;
+  setConfig: React.Dispatch<React.SetStateAction<SetupConfig>>;
+  restart: () => void;
+}
+
+export default function Dashboard({ config, setConfig, restart }: DashboardProps) {
+  const [editing, setEditing] = useState<string | null>(null);
+
+  const saveEnvironment = (gameKey: string, env: string) => {
+    setConfig((c) => ({
+      ...c,
+      games: {
+        ...c.games,
+        [gameKey]: { ...c.games[gameKey], environment: env }
+      }
+    }));
+    setEditing(null);
+  };
+
+  return (
+    <div>
+      <h2>Configuration Dashboard</h2>
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+        {Object.entries(config.games)
+          .filter(([, g]) => g.enabled)
+          .map(([key, g]) => {
+            const def = gameDefinitions.find((d) => d.key === key);
+            return (
+              <div
+                key={key}
+                style={{ border: '1px solid #ccc', padding: '1rem', width: '200px' }}
+              >
+                <h3>{def?.name || key}</h3>
+                <p>Environment: {g.environment || 'Not configured'}</p>
+                {def && def.environments.length > 0 ? (
+                  editing === key ? (
+                    <select
+                      value={g.environment || ''}
+                      onChange={(e) => saveEnvironment(key, e.target.value)}
+                    >
+                      <option value="">Select environment</option>
+                      {def.environments.map((env) => (
+                        <option key={env} value={env}>
+                          {env}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <button onClick={() => setEditing(key)}>Configure</button>
+                  )
+                ) : (
+                  <p>No configuration required</p>
+                )}
+              </div>
+            );
+          })}
+      </div>
+      <pre>{JSON.stringify(config, null, 2)}</pre>
+      <button onClick={restart}>Start over</button>
+    </div>
+  );
+}

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -1,0 +1,19 @@
+export interface GameDefinition {
+  key: string;
+  name: string;
+  environments: string[];
+}
+
+export const gameDefinitions: GameDefinition[] = [
+  { key: 'roulette', name: 'Roulette', environments: ['Flying', 'Multi', 'Touchbet'] },
+  {
+    key: 'lucky-ladys-roulette',
+    name: 'Lucky Ladys Roulette',
+    environments: ['Flying', 'Multi', 'Touchbet']
+  },
+  { key: 'baccarat', name: 'Baccarat', environments: ['Flying', 'Touchbet'] },
+  { key: 'blackjack', name: 'Blackjack', environments: ['Flying', 'Touchbet'] },
+  { key: 'poker', name: 'Poker', environments: ['Flying', 'Touchbet'] },
+  { key: 'sic-bo', name: 'Sic-Bo', environments: [] },
+  { key: 'slot-games', name: 'Slot Games', environments: [] }
+];

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,8 @@
+body {
+  font-family: sans-serif;
+  padding: 2rem;
+}
+
+button {
+  margin: 0.25rem;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- scaffold React + TypeScript app via Vite
- add landing page to start Unity configuration
- implement stepper to capture setup type, locations, games, jackpot and WAN options
- extend configurator with game environment dashboard
- ignore build artifacts and adjust app title

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*

------
https://chatgpt.com/codex/tasks/task_e_6890c045e6a4832584a01222fb2788dd